### PR TITLE
Update CI with np2 breaking change and python new version.

### DIFF
--- a/.github/workflows/ci-ubuntu.yml
+++ b/.github/workflows/ci-ubuntu.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/ci-windows.yml
+++ b/.github/workflows/ci-windows.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v2
         with:
           activate-environment: polze_env
-          python-version: 3.9
+          python-version: "3.11"
           auto-activate-base: false
           miniconda-version: "latest"
           auto-update-conda: true

--- a/polze/test.py
+++ b/polze/test.py
@@ -24,6 +24,11 @@ import numpy as np
 import cmath
 import sys
 
+# Numpy 2.0 change default printing options making doctest failing.
+# https://numpy.org/neps/nep-0051-scalar-representation.html
+# Use legacy mode for testing
+if np.lib.NumpyVersion(np.__version__) >= '2.0.0b1':
+    np.set_printoptions(legacy="1.25")
 
 # Define a non vectorized function
 # For parallel processing we need a function defined outside the class.


### PR DESCRIPTION
1. Update python versions and remove old versions
2.  Numpy 2.0 change the default printing options 
see https://numpy.org/neps/nep-0051-scalar-representation.html
This change crash doctests on scalars. For instance:

legacy:
```
>>> 2+np.int64(2)
4
```
New style:
```
>>> 2+np.int64(2)
np.int64(4)
```
This PR propose to use
```
np.set_printoptions(legacy="1.25")
```
Only in the test runner file, here `test.py`.

Perhaps we could change the format in doctest when numpy 2 will be more common.
